### PR TITLE
Update veilid-core dependency to v0.4.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ serde_cbor = "0.11.2"
 tokio = {version = "1.38.1", features = ["full", "tracing"]}
 tokio-stream = "0.1.15"
 tracing = "0.1.40"
-veilid-core = { git = "https://gitlab.com/veilid/veilid.git", tag = "v0.4.3" }
+veilid-core = { git = "https://gitlab.com/veilid/veilid.git", tag = "v0.4.4" }
 hex = "0.4"


### PR DESCRIPTION
  - Pin `veilid-core` to exact `tag = "v0.4.4"`