### PR TITLE
Upgrade to veilid (v0.5.1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "veilid-iroh-blobs"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [dependencies]
@@ -19,3 +19,6 @@ tokio-stream = "0.1.15"
 tracing = "0.1.40"
 veilid-core = { git = "https://gitlab.com/veilid/veilid.git", tag = "v0.5.1" }
 hex = "0.4"
+ # Temporary patch for Veilid fanout queue underflow bug
+[patch."https://gitlab.com/veilid/veilid.git"]
+veilid-core = { git = "https://gitlab.com/tripledoublev/veilid.git", branch = "fix-underflow" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ serde_cbor = "0.11.2"
 tokio = {version = "1.38.1", features = ["full", "tracing"]}
 tokio-stream = "0.1.15"
 tracing = "0.1.40"
-veilid-core = { git = "https://gitlab.com/veilid/veilid.git", tag = "v0.4.8" }
+veilid-core = { git = "https://gitlab.com/veilid/veilid.git", tag = "v0.5.1" }
 hex = "0.4"

--- a/src/iroh.rs
+++ b/src/iroh.rs
@@ -288,7 +288,7 @@ impl VeilidIrohBlobs {
         } else if command == NO {
             Ok(false)
         } else {
-            Err(anyhow!("Invalid response code from peer {:?}", command))
+            Err(anyhow!("Invalid response code from peer {command:?}"))
         }
     }
 
@@ -378,7 +378,7 @@ impl VeilidIrohBlobs {
         } else if command == NO {
             return Err(anyhow!("Peer does not have hash"));
         } else {
-            return Err(anyhow!("Invalid response code from peer {:?}", command));
+            return Err(anyhow!("Invalid response code from peer {command:?}"));
         }
     }
 
@@ -495,7 +495,7 @@ impl VeilidIrohBlobs {
         let collection_hash = self.collection_hash(collection_name).await?;
         let collection_data = self.read_bytes(collection_hash).await?;
         let collection: FileCollection = from_slice(&collection_data)
-            .map_err(|err| anyhow!("Failed to deserialize collection: {:?}", err))?;
+            .map_err(|err| anyhow!("Failed to deserialize collection: {err:?}"))?;
 
         Ok(collection)
     }
@@ -587,7 +587,7 @@ impl VeilidIrohBlobs {
         collection
             .get(path)
             .cloned()
-            .ok_or_else(|| anyhow!("File not found for path: {}", path))
+            .ok_or_else(|| anyhow!("File not found for path: {path}"))
     }
 
     pub async fn delete_file_from_collection_hash(
@@ -614,7 +614,7 @@ impl VeilidIrohBlobs {
     ) -> Result<HashMap<String, Hash>> {
         // Verify the collection exists
         if self.store.get(collection_hash).await?.is_none() {
-            return Err(anyhow!("Collection not found for hash: {}", collection_hash));
+            return Err(anyhow!("Collection not found for hash: {collection_hash}"));
         }
 
         // Read the serialized collection data directly
@@ -622,7 +622,7 @@ impl VeilidIrohBlobs {
 
         // Deserialize the collection into a HashMap
         let collection: HashMap<String, Hash> = from_slice(&collection_data)
-            .map_err(|err| anyhow!("Failed to deserialize collection: {:?}", err))?;
+            .map_err(|err| anyhow!("Failed to deserialize collection: {err:?}"))?;
 
         Ok(collection)
     }
@@ -632,19 +632,18 @@ impl VeilidIrohBlobs {
 
         for tag_result in tags {
             let (tag, hash_and_format) =
-                tag_result.map_err(|e| anyhow!("Error reading tags: {:?}", e))?;
+                tag_result.map_err(|e| anyhow!("Error reading tags: {e:?}"))?;
 
             // Check if the hash matches the provided collection_hash
             if hash_and_format.hash == *collection_hash {
                 // Convert the tag bytes to a String and return it as the collection name
                 return String::from_utf8(tag.0.to_vec())
-                    .map_err(|e| anyhow!("Failed to convert tag to String: {:?}", e));
+                    .map_err(|e| anyhow!("Failed to convert tag to String: {e:?}"));
             }
         }
 
         Err(anyhow!(
-            "Collection name not found for hash: {}",
-            collection_hash
+            "Collection name not found for hash: {collection_hash}"
         ))
     }
 
@@ -689,7 +688,7 @@ impl VeilidIrohBlobs {
 
         for tag_result in tags {
             let (tag, hash_and_format) =
-                tag_result.map_err(|e| anyhow!("Error reading tags: {:?}", e))?;
+                tag_result.map_err(|e| anyhow!("Error reading tags: {e:?}"))?;
 
             // Directly compare tag bytes with collection_name bytes
             if tag.0.as_ref().eq(collection_name_bytes) {
@@ -697,7 +696,7 @@ impl VeilidIrohBlobs {
             }
         }
 
-        Err(anyhow!("Tag not found for collection: {}", collection_name))
+        Err(anyhow!("Tag not found for collection: {collection_name}"))
     }
 
     pub async fn update_collection_with_name(
@@ -738,7 +737,7 @@ impl VeilidIrohBlobs {
     ) -> Result<Hash> {
         // Verify the old collection exists before creating new version
         if self.store.get(collection_hash).await?.is_none() {
-            return Err(anyhow!("Cannot update - collection hash {} not found", collection_hash));
+            return Err(anyhow!("Cannot update - collection hash {collection_hash} not found"));
         }
 
         // Serialize the updated HashMap to CBOR

--- a/src/iroh.rs
+++ b/src/iroh.rs
@@ -134,10 +134,18 @@ impl VeilidIrohBlobs {
         let listening_blobs = blobs.clone();
 
         let tunnels_handle = tokio::spawn(async move {
-            listening.listen(updates).await.unwrap();
+            if let Err(err) = listening.listen(updates).await {
+                eprintln!("TunnelManager listen failed: {err}");
+                // Also log via tracing if subscriber is configured
+                tracing::error!("TunnelManager listen failed: {err}");
+            }
         });
         let blobs_handle = tokio::spawn(async move {
-            listening_blobs.listen(read_tunnel).await.unwrap();
+            if let Err(err) = listening_blobs.listen(read_tunnel).await {
+                eprintln!("VeilidIrohBlobs listen failed: {err}");
+                // Also log via tracing if subscriber is configured
+                tracing::error!("VeilidIrohBlobs listen failed: {err}");
+            }
         });
 
         let mut handles = handles.lock().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -313,7 +313,7 @@ mod tests {
         let tunnels = crate::tunnels::TunnelManager::new(
             veilid.clone(),
             router,
-            route_id,
+            route_id.clone(),
             route_id_blob,
             None,
             Some(on_disconnected),
@@ -973,7 +973,7 @@ async fn init_veilid(
     });
 
     println!("Init veilid");
-    let veilid = veilid_core::api_startup_config(update_callback, config_inner).await?;
+    let veilid = veilid_core::api_startup(update_callback, config_inner).await?;
 
     println!("Attach veilid");
 
@@ -1023,8 +1023,8 @@ async fn make_route(veilid: &VeilidAPI) -> Result<(RouteId, Vec<u8>)> {
             )
             .await;
 
-        if let Ok(route) = result {
-            return Ok(route);
+        if let Ok(route_blob) = result {
+            return Ok((route_blob.route_id, route_blob.blob));
         }
     }
     Err(anyhow!("Unable to create route, reached max retries"))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,8 +272,7 @@ mod tests {
     async fn test_route_reset() {
         //unsafe { backtrace_on_stack_overflow::enable() }
 
-        let mut base_dir = PathBuf::new();
-        base_dir.push(".veilid");
+        let (base_dir, namespace) = get_test_config("test_route_reset");
 
         let (send_update, read_update) = broadcast::channel::<VeilidUpdate>(256);
         let (send_result, mut read_result) = mpsc::channel::<Result<()>>(2);
@@ -281,7 +280,7 @@ mod tests {
         let send_result1 = send_result.clone();
         let send_result2 = send_result.clone();
 
-        let (veilid, mut rx) = crate::init_veilid(Some("tunnels_test".to_string()), &base_dir)
+        let (veilid, mut rx) = crate::init_veilid(Some(namespace), &base_dir)
             .await
             .expect("Unable to init veilid and store");
 
@@ -374,10 +373,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_blob_replication() {
-        let mut base_dir = PathBuf::new();
-        base_dir.push(".veilid");
-        let replication_dir = base_dir.join("replication");
-        let (veilid, mut rx) = crate::init_veilid(Some("blob_replication_test".to_string()), &replication_dir).await.unwrap();
+        let (base_dir, namespace) = get_test_config("test_blob_replication");
+        let (veilid, mut rx) = crate::init_veilid(Some(namespace), &base_dir).await.unwrap();
 
         let (send_update, read_update) = broadcast::channel::<VeilidUpdate>(256);
         let read_update1 = read_update;
@@ -399,12 +396,12 @@ mod tests {
         let v1 = veilid.clone();
         let v2 = veilid.clone();
 
-        let store1_dir = replication_dir.join("peer1");
+        let store1_dir = base_dir.join("peer1");
         let store1 = iroh_blobs::store::fs::Store::load(store1_dir)
             .await
             .unwrap();
 
-        let store2_dir = replication_dir.join("peer2");
+        let store2_dir = base_dir.join("peer2");
         let store2 = iroh_blobs::store::fs::Store::load(store2_dir)
             .await
             .unwrap();

--- a/src/tunnels.rs
+++ b/src/tunnels.rs
@@ -4,7 +4,6 @@ use bytes::BufMut;
 use bytes::Bytes;
 use bytes::BytesMut;
 use std::collections::HashMap;
-use std::io::Write;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::Receiver;
@@ -14,7 +13,7 @@ use veilid_core::OperationId;
 use veilid_core::VeilidAPI;
 use veilid_core::VeilidAppCall;
 use veilid_core::VALID_CRYPTO_KINDS;
-use veilid_core::{RouteId, RoutingContext, Target, VeilidUpdate, CRYPTO_KEY_LENGTH};
+use veilid_core::{RouteId, RoutingContext, Target, VeilidUpdate};
 
 pub type Tunnel = (Sender<Vec<u8>>, Receiver<Vec<u8>>);
 pub type TunnelId = (RouteId, u32);
@@ -72,11 +71,12 @@ impl TunnelManagerInner {
     }
 
     async fn send_bytes(&self, id: &TunnelId, bytes: Vec<u8>) -> Result<()> {
-        let mut buffer: BytesMut = BytesMut::with_capacity(bytes.len() + 4 + CRYPTO_KEY_LENGTH);
-        buffer.put(self.route_id.bytes.to_vec().as_slice());
+        let route_id_bytes = Vec::from(self.route_id.clone());
+        let mut buffer: BytesMut = BytesMut::with_capacity(bytes.len() + 4 + route_id_bytes.len());
+        buffer.put(route_id_bytes.as_slice());
         buffer.put_u32(id.1);
         buffer.put(bytes.as_slice());
-        let target = Target::PrivateRoute(id.0);
+        let target = Target::RouteId(id.0.clone());
         let result = self.router.app_call(target, buffer.to_vec()).await?;
 
         if result.len() != 1 {
@@ -132,7 +132,7 @@ impl TunnelManagerInner {
             }
             // TODO: Better error handling?
             let (route_id, route_id_blob) = make_route(&self.veilid).await.unwrap();
-            self.route_id = route_id;
+            self.route_id = route_id.clone();
             self.route_id_blob = route_id_blob.clone();
             if let Some(callback) = &self.on_new_route_callback {
                 callback(route_id, route_id_blob);
@@ -150,11 +150,11 @@ impl TunnelManager {
         {
             let mut inner = self.inner.lock().await;
 
-            inner.senders.insert(*id, man_to_tun);
+            inner.senders.insert(id.clone(), man_to_tun);
         }
 
         let inner = self.inner.clone();
-        let id = *id;
+        let id = id.clone();
         let route_id = self.route_id().await;
 
         tokio::spawn(async move {
@@ -250,18 +250,19 @@ impl TunnelManager {
 
         let mut buffer = Bytes::copy_from_slice(app_call.message());
 
-        // THis is all to read 32 bytes into a fixed buffer 💀
-        let route_id_buffer = buffer.get(0..32);
+        // Read route_id bytes (variable length based on crypto kind)
+        let current_route_id = self.route_id().await;
+        let route_id_len = Vec::from(current_route_id).len();
+        let route_id_buffer = buffer.get(0..route_id_len);
         if route_id_buffer.is_none() {
             return Ok(());
         }
         let route_id_buffer = route_id_buffer.unwrap();
-        let mut route_key_raw: [u8; CRYPTO_KEY_LENGTH] = [0; CRYPTO_KEY_LENGTH];
-        route_key_raw.writer().write_all(route_id_buffer)?;
-        let route_key = RouteId { bytes: route_key_raw };
+        let route_key = RouteId::try_from(route_id_buffer.to_vec())
+            .map_err(|e| anyhow!("Failed to parse RouteId: {}", e))?;
 
         // Apparently .get(index) doesn't advance the buffer 🤷
-        buffer.advance(32);
+        buffer.advance(route_id_len);
 
         let tunnel_number = buffer.get_u32();
         let bytes = buffer.chunk();
@@ -298,7 +299,9 @@ impl TunnelManager {
         on_new_route_callback: Option<OnNewRouteCallback>,
     ) -> Result<Self> {
         let router = veilid.routing_context()?;
-        let (route_id, route_id_blob) = veilid.new_private_route().await?;
+        let route_blob = veilid.new_private_route().await?;
+        let route_id = route_blob.route_id;
+        let route_id_blob = route_blob.blob;
 
         Ok(Self::new(
             veilid,
@@ -341,7 +344,7 @@ impl TunnelManager {
     pub async fn route_id(&self) -> RouteId {
         let inner = self.inner.lock().await;
 
-        inner.route_id
+        inner.route_id.clone()
     }
 
     pub async fn route_id_blob(&self) -> Vec<u8> {
@@ -413,8 +416,8 @@ async fn make_route(veilid: &VeilidAPI) -> Result<(RouteId, Vec<u8>)> {
             )
             .await;
 
-        if let Ok(route) = result {
-            return Ok(route);
+        if let Ok(route_blob) = result {
+            return Ok((route_blob.route_id, route_blob.blob));
         }
     }
     Err(anyhow!("Unable to create route, reached max retries"))

--- a/src/tunnels.rs
+++ b/src/tunnels.rs
@@ -40,7 +40,7 @@ impl TryFrom<u8> for TunnelResult {
             x if x == TunnelResult::Success as u8 => Ok(TunnelResult::Success),
             x if x == TunnelResult::InvalidFormat as u8 => Ok(TunnelResult::InvalidFormat),
             x if x == TunnelResult::Closed as u8 => Ok(TunnelResult::Closed),
-            _ => Err(anyhow!("Invalid tunnel result value {:?}", v)),
+            _ => Err(anyhow!("Invalid tunnel result value {v:?}")),
         }
     }
 }
@@ -81,8 +81,7 @@ impl TunnelManagerInner {
 
         if result.len() != 1 {
             return Err(anyhow!(
-                "Got invalid response length from app call: {:?}",
-                result
+                "Got invalid response length from app call: {result:?}"
             ));
         }
 
@@ -105,7 +104,7 @@ impl TunnelManagerInner {
             .unwrap()
             .send(bytes.to_vec())
             .await
-            .map_err(|err| anyhow!("Unable to send: {}", err))
+            .map_err(|err| anyhow!("Unable to send: {err}"))
     }
 
     async fn handle_remote_dead(&mut self, routes: &[RouteId]) {
@@ -180,9 +179,7 @@ impl TunnelManager {
         let ping = &message[0..PING_BYTES.len()];
         if !ping.eq(PING_BYTES) {
             return Err(anyhow!(
-                "Got invalid length for ping: {:?}\n Expected: {:?}",
-                ping,
-                PING_BYTES
+                "Got invalid length for ping: {ping:?}\n Expected: {PING_BYTES:?}"
             ));
         }
 
@@ -259,7 +256,7 @@ impl TunnelManager {
         }
         let route_id_buffer = route_id_buffer.unwrap();
         let route_key = RouteId::try_from(route_id_buffer.to_vec())
-            .map_err(|e| anyhow!("Failed to parse RouteId: {}", e))?;
+            .map_err(|e| anyhow!("Failed to parse RouteId: {e}"))?;
 
         // Apparently .get(index) doesn't advance the buffer 🤷
         buffer.advance(route_id_len);


### PR DESCRIPTION
- uupgrades `veilid-core` from **v0.4.8** to **v0.5.1** 
- applies the necessary API changes
- includes a temporary patch for a fanout queue underflow bug

**API migration (0.4 → 0.5)**
- Startup: `api_startup_config` → `api_startup`
- Route creation: `new_custom_private_route` / `new_private_route` now return `RouteBlob { route_id, blob }` instead of a tuple; call sites updated in `lib.rs` and `tunnels.rs`
- `Target::PrivateRoute` → `Target::RouteId`
- `RouteId`: fixed 32-byte / `CRYPTO_KEY_LENGTH` usage replaced with variable-length handling via `Vec::from(route_id)` and `RouteId::try_from(...)` for parsing
- Extra `.clone()` where 0.5 types are no longer `Copy`

### Follow-up

- Remove the `[patch]` once the underflow fix is in upstream Veilid and we bump to that release.

---