### PR TITLE
Handle malformed tunnel app calls

### DIFF
--- a/src/iroh.rs
+++ b/src/iroh.rs
@@ -27,7 +27,10 @@ use std::collections::HashMap;
 use std::io::ErrorKind;
 use std::sync::Mutex;
 use std::time::Duration;
-use std::{path::{Path, PathBuf}, sync::Arc};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 use tokio::sync::broadcast::Receiver;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
@@ -737,7 +740,9 @@ impl VeilidIrohBlobs {
     ) -> Result<Hash> {
         // Verify the old collection exists before creating new version
         if self.store.get(collection_hash).await?.is_none() {
-            return Err(anyhow!("Cannot update - collection hash {collection_hash} not found"));
+            return Err(anyhow!(
+                "Cannot update - collection hash {collection_hash} not found"
+            ));
         }
 
         // Serialize the updated HashMap to CBOR

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,10 @@
 #![recursion_limit = "256"]
 use anyhow::anyhow;
 use anyhow::Result;
-use std::{path::{Path, PathBuf}, sync::Arc};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 use tokio::sync::broadcast;
 use tokio::sync::broadcast::Receiver;
 use veilid_core::{
@@ -10,6 +13,108 @@ use veilid_core::{
 
 pub mod iroh;
 pub mod tunnels;
+
+async fn init_veilid(
+    namespace: Option<String>,
+    base_dir: &Path,
+) -> Result<(VeilidAPI, Receiver<VeilidUpdate>)> {
+    let config_inner = config_for_dir(base_dir.to_path_buf(), namespace);
+
+    let (tx, mut rx) = broadcast::channel(32);
+
+    let update_callback: UpdateCallback = Arc::new(move |update| {
+        let tx = tx.clone();
+        tokio::spawn(async move {
+            if tx.send(update).is_err() {
+                // TODO:
+                println!("receiver dropped");
+            }
+        });
+    });
+
+    println!("Init veilid");
+    let veilid = veilid_core::api_startup(update_callback, config_inner).await?;
+
+    println!("Attach veilid");
+
+    veilid.attach().await?;
+
+    println!("Wait for veilid network");
+
+    while let Ok(update) = rx.recv().await {
+        if let VeilidUpdate::Attachment(attachment_state) = update {
+            if attachment_state.public_internet_ready && attachment_state.state.is_attached() {
+                println!("Public internet ready!");
+                break;
+            }
+        }
+    }
+
+    println!("Network ready");
+
+    Ok((veilid, rx))
+}
+
+async fn init_deps(
+    namespace: Option<String>,
+    base_dir: &Path,
+) -> Result<(
+    VeilidAPI,
+    Receiver<VeilidUpdate>,
+    iroh_blobs::store::fs::Store,
+)> {
+    let store = iroh_blobs::store::fs::Store::load(base_dir.join("iroh")).await?;
+
+    let (veilid, rx) = init_veilid(namespace, base_dir).await?;
+
+    Ok((veilid, rx, store))
+}
+
+// TODO: Put these into a utils module or something
+async fn make_route(veilid: &VeilidAPI) -> Result<(RouteId, Vec<u8>)> {
+    let mut retries = 3;
+    while retries != 0 {
+        retries -= 1;
+        let result = veilid
+            .new_custom_private_route(
+                &VALID_CRYPTO_KINDS,
+                veilid_core::Stability::LowLatency,
+                veilid_core::Sequencing::NoPreference,
+            )
+            .await;
+
+        if let Ok(route_blob) = result {
+            return Ok((route_blob.route_id, route_blob.blob));
+        }
+    }
+    Err(anyhow!("Unable to create route, reached max retries"))
+}
+
+fn config_for_dir(base_dir: PathBuf, namespace: Option<String>) -> VeilidConfig {
+    let namespace: String = namespace.unwrap_or_else(|| "iroh-blobs".to_string());
+    VeilidConfig {
+        program_name: "iroh-blobs".to_string(),
+        namespace,
+        protected_store: veilid_core::VeilidConfigProtectedStore {
+            // avoid prompting for password, don't do this in production
+            always_use_insecure_storage: true,
+            directory: base_dir
+                .join("protected_store")
+                .to_string_lossy()
+                .to_string(),
+            ..Default::default()
+        },
+        table_store: veilid_core::VeilidConfigTableStore {
+            directory: base_dir.join("table_store").to_string_lossy().to_string(),
+            ..Default::default()
+        },
+        block_store: veilid_core::VeilidConfigBlockStore {
+            directory: base_dir.join("block_store").to_string_lossy().to_string(),
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -37,9 +142,9 @@ mod tests {
             .unwrap()
             .as_nanos();
         let mut dir = PathBuf::from(".veilid-test");
-        dir.push(format!("{}-{}", test_name, timestamp));
+        dir.push(format!("{test_name}-{timestamp}"));
         // Create unique namespace - this is critical for Veilid's global INITIALIZED HashSet
-        let namespace = format!("{}-{}", test_name, timestamp);
+        let namespace = format!("{test_name}-{timestamp}");
         (dir, namespace)
     }
 
@@ -75,16 +180,15 @@ mod tests {
         let read_update1 = read_update;
         let read_update2 = send_update.subscribe();
 
-        let (veilid, mut rx) =
-            crate::init_veilid(Some(namespace), &base_dir)
-                .await
-                .expect("Unable to init veilid and store");
+        let (veilid, mut rx) = crate::init_veilid(Some(namespace), &base_dir)
+            .await
+            .expect("Unable to init veilid and store");
 
         let sender_handle = tokio::spawn(async move {
             while let Ok(update) = rx.recv().await {
                 //println!("Received update: {:#?}", update);
                 if let Err(err) = send_update.send(update) {
-                    eprintln!("Unable to process veilid update: {:?}", err);
+                    eprintln!("Unable to process veilid update: {err:?}");
                 }
             }
         });
@@ -106,7 +210,7 @@ mod tests {
         println!("Routes ready");
 
         let on_new_tunnel1: OnNewTunnelCallback = Arc::new(move |tunnel| {
-            println!("New tunnel {:?}", tunnel);
+            println!("New tunnel {tunnel:?}");
 
             let send_result1 = send_result1.clone();
 
@@ -133,7 +237,7 @@ mod tests {
                     send_result1.send(Ok(())).await.unwrap();
                 } else {
                     send_result1
-                        .send(Err(anyhow!("Got invalid message from tunnel {0}", message)))
+                        .send(Err(anyhow!("Got invalid message from tunnel {message}")))
                         .await
                         .unwrap();
                 }
@@ -224,17 +328,17 @@ mod tests {
             match result {
                 Err(_) => {
                     send_result2
-                        .send(Err(anyhow!("Timeout waiting for tunnel response (network timing issue)")))
+                        .send(Err(anyhow!(
+                            "Timeout waiting for tunnel response (network timing issue)"
+                        )))
                         .await
                         .unwrap();
-                    return;
                 }
                 Ok(None) => {
                     send_result2
                         .send(Err(anyhow!("Tunnel closed before receiving response")))
                         .await
                         .unwrap();
-                    return;
                 }
                 Ok(Some(raw)) => {
                     let message = str::from_utf8(raw.as_slice()).unwrap();
@@ -243,7 +347,7 @@ mod tests {
                         send_result2.send(Ok(())).await.unwrap();
                     } else {
                         send_result2
-                            .send(Err(anyhow!("Got invalid message from tunnel {0}", message)))
+                            .send(Err(anyhow!("Got invalid message from tunnel {message}")))
                             .await
                             .unwrap();
                     }
@@ -288,7 +392,7 @@ mod tests {
             while let Ok(update) = rx.recv().await {
                 //println!("Received update: {:#?}", update);
                 if let Err(err) = send_update.send(update) {
-                    eprintln!("Unable to process veilid update: {:?}", err);
+                    eprintln!("Unable to process veilid update: {err:?}");
                 }
             }
         });
@@ -354,7 +458,7 @@ mod tests {
             .await
             .unwrap();
 
-        println!("Hash of README: {0}", hash);
+        println!("Hash of README: {hash}");
 
         let receiver = blobs.read_file(hash).await.unwrap();
 
@@ -362,11 +466,11 @@ mod tests {
 
         let data = stream.next().await;
 
-        println!("{:?}", data);
+        println!("{data:?}");
 
         let has = blobs.has_hash(&hash).await;
 
-        println!("Blobs has hash: {}", has);
+        println!("Blobs has hash: {has}");
 
         shutdown_blobs(blobs).await;
     }
@@ -374,7 +478,9 @@ mod tests {
     #[tokio::test]
     async fn test_blob_replication() {
         let (base_dir, namespace) = get_test_config("test_blob_replication");
-        let (veilid, mut rx) = crate::init_veilid(Some(namespace), &base_dir).await.unwrap();
+        let (veilid, mut rx) = crate::init_veilid(Some(namespace), &base_dir)
+            .await
+            .unwrap();
 
         let (send_update, read_update) = broadcast::channel::<VeilidUpdate>(256);
         let read_update1 = read_update;
@@ -383,12 +489,12 @@ mod tests {
         let sender_handle = tokio::spawn(async move {
             while let Result::Ok(update) = rx.recv().await {
                 if let VeilidUpdate::RouteChange(change) = update {
-                    println!("Route change {:?}", change);
+                    println!("Route change {change:?}");
                     continue;
                 }
                 //println!("Received update: {:#?}", update);
                 if let Err(err) = send_update.send(update) {
-                    eprintln!("Unable to process veilid update: {:?}", err);
+                    eprintln!("Unable to process veilid update: {err:?}");
                 }
             }
         });
@@ -460,7 +566,7 @@ mod tests {
         let (base_dir, namespace) = get_test_config("test_create_collection");
 
         // Log: Initializing blobs instance
-        println!("Initializing blobs instance from directory: {:?}", base_dir);
+        println!("Initializing blobs instance from directory: {base_dir:?}");
 
         // Initialize the blobs instance
         let blobs = VeilidIrohBlobs::from_directory(&base_dir, Some(namespace), None, None)
@@ -483,7 +589,7 @@ mod tests {
             "Collection hash should not be empty"
         );
 
-        println!("The collection was created with hash: {}", collection_hash);
+        println!("The collection was created with hash: {collection_hash}");
 
         // Verify that the collection exists in the store
         let has_collection = blobs.has_hash(&collection_hash).await;
@@ -517,7 +623,7 @@ mod tests {
             !collection_hash.as_bytes().is_empty(),
             "Collection hash should not be empty"
         );
-        println!("Created collection with hash: {}", collection_hash);
+        println!("Created collection with hash: {collection_hash}");
 
         // Test set_file
         let file_path = "test_file.txt".to_string();
@@ -532,10 +638,10 @@ mod tests {
         let file_hash = blobs.upload_from_path(temp_file_path).await.unwrap();
 
         // Add debug statements
-        println!("File hash: {}", file_hash);
+        println!("File hash: {file_hash}");
 
         let has_file = blobs.has_hash(&file_hash).await;
-        println!("Has file: {}", has_file);
+        println!("Has file: {has_file}");
         assert!(has_file, "Store should have the file hash after upload");
 
         let updated_collection_hash = blobs
@@ -638,19 +744,16 @@ mod tests {
             !collection_hash.as_bytes().is_empty(),
             "Collection hash should not be empty"
         );
-        println!("Created collection with hash: {}", collection_hash);
+        println!("Created collection with hash: {collection_hash}");
 
         // Attempt to retrieve the tag
-        println!(
-            "Attempting to retrieve tag for collection: {}",
-            collection_name
-        );
+        println!("Attempting to retrieve tag for collection: {collection_name}");
         match blobs.get_tag(&collection_name).await {
             Ok(tag_hash) => {
-                println!("Successfully retrieved tag: {:?}", tag_hash);
+                println!("Successfully retrieved tag: {tag_hash:?}");
             }
             Err(e) => {
-                println!("Error retrieving tag: {:?}", e);
+                println!("Error retrieving tag: {e:?}");
             }
         }
 
@@ -661,10 +764,10 @@ mod tests {
         let temp_file_path = std::fs::canonicalize(temp_file_path).unwrap();
 
         let file_hash = blobs.upload_from_path(temp_file_path).await.unwrap();
-        println!("File hash: {}", file_hash);
+        println!("File hash: {file_hash}");
 
         let has_file = blobs.has_hash(&file_hash).await;
-        println!("Has file: {}", has_file);
+        println!("Has file: {has_file}");
         assert!(has_file, "Store should have the file hash after upload");
 
         let updated_collection_hash = blobs
@@ -875,10 +978,7 @@ mod tests {
 
         // Attempt to retrieve a file from a non-existent collection
         let result = blobs
-            .get_file(
-                &"non_existent_collection".to_string(),
-                &"some_file.txt".to_string(),
-            )
+            .get_file("non_existent_collection", "some_file.txt")
             .await;
         assert!(
             result.is_err(),
@@ -886,9 +986,7 @@ mod tests {
         );
 
         // Attempt to list files in a non-existent collection
-        let result = blobs
-            .list_files(&"non_existent_collection".to_string())
-            .await;
+        let result = blobs.list_files("non_existent_collection").await;
         assert!(
             result.is_err(),
             "Listing files from non-existent collection should fail"
@@ -948,107 +1046,5 @@ mod tests {
         );
 
         shutdown_blobs(blobs).await;
-    }
-}
-
-async fn init_veilid(
-    namespace: Option<String>,
-    base_dir: &Path,
-) -> Result<(VeilidAPI, Receiver<VeilidUpdate>)> {
-    let config_inner = config_for_dir(base_dir.to_path_buf(), namespace);
-
-    let (tx, mut rx) = broadcast::channel(32);
-
-    let update_callback: UpdateCallback = Arc::new(move |update| {
-        let tx = tx.clone();
-        tokio::spawn(async move {
-            if tx.send(update).is_err() {
-                // TODO:
-                println!("receiver dropped");
-            }
-        });
-    });
-
-    println!("Init veilid");
-    let veilid = veilid_core::api_startup(update_callback, config_inner).await?;
-
-    println!("Attach veilid");
-
-    veilid.attach().await?;
-
-    println!("Wait for veilid network");
-
-    while let Ok(update) = rx.recv().await {
-        if let VeilidUpdate::Attachment(attachment_state) = update {
-            if attachment_state.public_internet_ready && attachment_state.state.is_attached() {
-                println!("Public internet ready!");
-                break;
-            }
-        }
-    }
-
-    println!("Network ready");
-
-    Ok((veilid, rx))
-}
-
-async fn init_deps(
-    namespace: Option<String>,
-    base_dir: &Path,
-) -> Result<(
-    VeilidAPI,
-    Receiver<VeilidUpdate>,
-    iroh_blobs::store::fs::Store,
-)> {
-    let store = iroh_blobs::store::fs::Store::load(base_dir.join("iroh")).await?;
-
-    let (veilid, rx) = init_veilid(namespace, base_dir).await?;
-
-    Ok((veilid, rx, store))
-}
-
-// TODO: Put these into a utils module or something
-async fn make_route(veilid: &VeilidAPI) -> Result<(RouteId, Vec<u8>)> {
-    let mut retries = 3;
-    while retries != 0 {
-        retries -= 1;
-        let result = veilid
-            .new_custom_private_route(
-                &VALID_CRYPTO_KINDS,
-                veilid_core::Stability::LowLatency,
-                veilid_core::Sequencing::NoPreference,
-            )
-            .await;
-
-        if let Ok(route_blob) = result {
-            return Ok((route_blob.route_id, route_blob.blob));
-        }
-    }
-    Err(anyhow!("Unable to create route, reached max retries"))
-}
-
-fn config_for_dir(base_dir: PathBuf, namespace: Option<String>) -> VeilidConfig {
-    let namespace: String = namespace.unwrap_or_else(|| "iroh-blobs".to_string());
-    VeilidConfig {
-        program_name: "iroh-blobs".to_string(),
-        namespace,
-        protected_store: veilid_core::VeilidConfigProtectedStore {
-            // avoid prompting for password, don't do this in production
-            always_use_insecure_storage: true,
-            directory: base_dir
-                .join("protected_store")
-                .to_string_lossy()
-                .to_string(),
-            ..Default::default()
-        },
-        table_store: veilid_core::VeilidConfigTableStore {
-            directory: base_dir.join("table_store").to_string_lossy().to_string(),
-            ..Default::default()
-        },
-        block_store: veilid_core::VeilidConfigBlockStore {
-            directory: base_dir.join("block_store").to_string_lossy().to_string(),
-            ..Default::default()
-        },
-        ..Default::default()
     }
 }

--- a/src/tunnels.rs
+++ b/src/tunnels.rs
@@ -34,8 +34,8 @@ pub enum TunnelResult {
 }
 
 enum TunnelError {
-    InvalidFrame(anyhow::Error),
-    Delivery(anyhow::Error),
+    InvalidFrame,
+    Delivery,
 }
 
 impl TryFrom<u8> for TunnelResult {
@@ -236,12 +236,12 @@ impl TunnelManager {
             if let Err(err) = self.send_to_tunnel(id, message).await {
                 let route_id = self.route_id().await;
                 error!(route_id = ?route_id, error = ?err, "Unable to send data to tunnel");
-                return Err(TunnelError::Delivery(err));
+                return Err(TunnelError::Delivery);
             }
         } else if let Err(err) = self.handle_new(id, message).await {
             let route_id = self.route_id().await;
             error!(route_id = ?route_id, error = ?err, "Unable to handle new tunnel");
-            return Err(TunnelError::InvalidFrame(err));
+            return Err(TunnelError::InvalidFrame);
         }
 
         Ok(())
@@ -297,14 +297,11 @@ impl TunnelManager {
 
         match self.handle_message(&id, bytes).await {
             Ok(_) => self.app_call_reply(call_id, TunnelResult::Success).await,
-            Err(TunnelError::InvalidFrame(_)) => {
+            Err(TunnelError::InvalidFrame) => {
                 self.app_call_reply(call_id, TunnelResult::InvalidFormat)
                     .await
             }
-            Err(TunnelError::Delivery(_)) => {
-                self.app_call_reply(call_id, TunnelResult::Closed)
-                    .await
-            }
+            Err(TunnelError::Delivery) => self.app_call_reply(call_id, TunnelResult::Closed).await,
         }
     }
 

--- a/src/tunnels.rs
+++ b/src/tunnels.rs
@@ -9,6 +9,7 @@ use tokio::sync::mpsc;
 use tokio::sync::mpsc::Receiver;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::Mutex;
+use tracing::error;
 use veilid_core::OperationId;
 use veilid_core::VeilidAPI;
 use veilid_core::VeilidAppCall;
@@ -228,19 +229,13 @@ impl TunnelManager {
         if self.has_tunnel(id).await {
             // TODO: Log failed requests?
             if let Err(err) = self.send_to_tunnel(id, message).await {
-                eprintln!(
-                    "{0} Unable to send data to tunnel {1:?}",
-                    self.route_id().await,
-                    err
-                );
+                let route_id = self.route_id().await;
+                error!(route_id = ?route_id, error = ?err, "Unable to send data to tunnel");
                 return Err(err);
             }
         } else if let Err(err) = self.handle_new(id, message).await {
-            eprintln!(
-                "{0} Unable to handle new tunnel {1:?}",
-                self.route_id().await,
-                err
-            );
+            let route_id = self.route_id().await;
+            error!(route_id = ?route_id, error = ?err, "Unable to handle new tunnel");
             return Err(err);
         }
 
@@ -274,7 +269,7 @@ impl TunnelManager {
         let route_key = match RouteId::try_from(route_id_buffer.to_vec()) {
             Ok(route_key) => route_key,
             Err(err) => {
-                eprintln!("Failed to parse tunnel route id: {err}");
+                error!(error = ?err, "Failed to parse tunnel route id");
                 return self
                     .app_call_reply(call_id, TunnelResult::InvalidFormat)
                     .await;

--- a/src/tunnels.rs
+++ b/src/tunnels.rs
@@ -33,6 +33,11 @@ pub enum TunnelResult {
     Closed = 2,
 }
 
+enum TunnelError {
+    InvalidFrame(anyhow::Error),
+    Delivery(anyhow::Error),
+}
+
 impl TryFrom<u8> for TunnelResult {
     type Error = anyhow::Error;
 
@@ -225,18 +230,18 @@ impl TunnelManager {
         inner.senders.contains_key(id)
     }
 
-    async fn handle_message(&self, id: &TunnelId, message: &[u8]) -> Result<()> {
+    async fn handle_message(&self, id: &TunnelId, message: &[u8]) -> Result<(), TunnelError> {
         if self.has_tunnel(id).await {
             // TODO: Log failed requests?
             if let Err(err) = self.send_to_tunnel(id, message).await {
                 let route_id = self.route_id().await;
                 error!(route_id = ?route_id, error = ?err, "Unable to send data to tunnel");
-                return Err(err);
+                return Err(TunnelError::Delivery(err));
             }
         } else if let Err(err) = self.handle_new(id, message).await {
             let route_id = self.route_id().await;
             error!(route_id = ?route_id, error = ?err, "Unable to handle new tunnel");
-            return Err(err);
+            return Err(TunnelError::InvalidFrame(err));
         }
 
         Ok(())
@@ -292,8 +297,12 @@ impl TunnelManager {
 
         match self.handle_message(&id, bytes).await {
             Ok(_) => self.app_call_reply(call_id, TunnelResult::Success).await,
-            Err(_) => {
+            Err(TunnelError::InvalidFrame(_)) => {
                 self.app_call_reply(call_id, TunnelResult::InvalidFormat)
+                    .await
+            }
+            Err(TunnelError::Delivery(_)) => {
+                self.app_call_reply(call_id, TunnelResult::Closed)
                     .await
             }
         }

--- a/src/tunnels.rs
+++ b/src/tunnels.rs
@@ -458,7 +458,7 @@ mod tests {
 
     #[test]
     fn new_tunnel_route_blob_rejects_short_messages() {
-        let err = TunnelManager::new_tunnel_route_blob(&[TunnelResult::InvalidFormat as u8])
+        let err = TunnelManager::new_tunnel_route_blob(&[99])
             .expect_err("short new-tunnel messages should be rejected, not sliced");
 
         assert!(
@@ -480,6 +480,14 @@ mod tests {
     }
 
     #[test]
+    fn new_tunnel_route_blob_returns_empty_slice_when_only_ping() {
+        let route_blob = TunnelManager::new_tunnel_route_blob(PING_BYTES)
+            .expect("message with only ping prefix should return empty slice");
+
+        assert!(route_blob.is_empty());
+    }
+
+    #[test]
     fn new_tunnel_route_blob_returns_route_blob_after_ping() {
         let mut message = PING_BYTES.to_vec();
         message.extend([1, 2, 3]);
@@ -488,5 +496,17 @@ mod tests {
             .expect("valid ping prefix should return the remaining route blob");
 
         assert_eq!(route_blob, &[1, 2, 3]);
+    }
+
+    #[test]
+    fn new_tunnel_route_blob_handles_large_payloads() {
+        let mut message = PING_BYTES.to_vec();
+        message.extend(vec![42u8; 1024]);
+
+        let route_blob = TunnelManager::new_tunnel_route_blob(&message)
+            .expect("large payloads should be parsed correctly");
+
+        assert_eq!(route_blob.len(), 1024);
+        assert!(route_blob.iter().all(|b| *b == 42u8));
     }
 }

--- a/src/tunnels.rs
+++ b/src/tunnels.rs
@@ -142,6 +142,25 @@ impl TunnelManagerInner {
 }
 
 impl TunnelManager {
+    fn new_tunnel_route_blob(message: &[u8]) -> Result<&[u8]> {
+        if message.len() < PING_BYTES.len() {
+            return Err(anyhow!(
+                "Invalid new tunnel message length: got {}, expected at least {}",
+                message.len(),
+                PING_BYTES.len()
+            ));
+        }
+
+        let ping = &message[..PING_BYTES.len()];
+        if ping != PING_BYTES {
+            return Err(anyhow!(
+                "Invalid tunnel ping prefix: {ping:?}\n Expected: {PING_BYTES:?}"
+            ));
+        }
+
+        Ok(&message[PING_BYTES.len()..])
+    }
+
     async fn track(&self, id: &TunnelId) -> Result<Tunnel> {
         let (man_to_tun, from_man_to_tun) = mpsc::channel(100);
         let (tun_to_man, mut from_tun_to_man) = mpsc::channel::<Vec<u8>>(100);
@@ -176,14 +195,7 @@ impl TunnelManager {
     }
 
     async fn handle_new(&self, id: &TunnelId, message: &[u8]) -> Result<()> {
-        let ping = &message[0..PING_BYTES.len()];
-        if !ping.eq(PING_BYTES) {
-            return Err(anyhow!(
-                "Got invalid length for ping: {ping:?}\n Expected: {PING_BYTES:?}"
-            ));
-        }
-
-        let route_id_blob = &message[PING_BYTES.len()..];
+        let route_id_blob = Self::new_tunnel_route_blob(message)?;
 
         let route_id = self
             .veilid
@@ -221,6 +233,7 @@ impl TunnelManager {
                     self.route_id().await,
                     err
                 );
+                return Err(err);
             }
         } else if let Err(err) = self.handle_new(id, message).await {
             eprintln!(
@@ -228,6 +241,7 @@ impl TunnelManager {
                 self.route_id().await,
                 err
             );
+            return Err(err);
         }
 
         Ok(())
@@ -252,14 +266,29 @@ impl TunnelManager {
         let route_id_len = Vec::from(current_route_id).len();
         let route_id_buffer = buffer.get(0..route_id_len);
         if route_id_buffer.is_none() {
-            return Ok(());
+            return self
+                .app_call_reply(call_id, TunnelResult::InvalidFormat)
+                .await;
         }
         let route_id_buffer = route_id_buffer.unwrap();
-        let route_key = RouteId::try_from(route_id_buffer.to_vec())
-            .map_err(|e| anyhow!("Failed to parse RouteId: {e}"))?;
+        let route_key = match RouteId::try_from(route_id_buffer.to_vec()) {
+            Ok(route_key) => route_key,
+            Err(err) => {
+                eprintln!("Failed to parse tunnel route id: {err}");
+                return self
+                    .app_call_reply(call_id, TunnelResult::InvalidFormat)
+                    .await;
+            }
+        };
 
         // Apparently .get(index) doesn't advance the buffer 🤷
         buffer.advance(route_id_len);
+
+        if buffer.remaining() < std::mem::size_of::<u32>() {
+            return self
+                .app_call_reply(call_id, TunnelResult::InvalidFormat)
+                .await;
+        }
 
         let tunnel_number = buffer.get_u32();
         let bytes = buffer.chunk();
@@ -268,7 +297,10 @@ impl TunnelManager {
 
         match self.handle_message(&id, bytes).await {
             Ok(_) => self.app_call_reply(call_id, TunnelResult::Success).await,
-            Err(_) => self.app_call_reply(call_id, TunnelResult::Closed).await,
+            Err(_) => {
+                self.app_call_reply(call_id, TunnelResult::InvalidFormat)
+                    .await
+            }
         }
     }
 
@@ -418,4 +450,43 @@ async fn make_route(veilid: &VeilidAPI) -> Result<(RouteId, Vec<u8>)> {
         }
     }
     Err(anyhow!("Unable to create route, reached max retries"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_tunnel_route_blob_rejects_short_messages() {
+        let err = TunnelManager::new_tunnel_route_blob(&[TunnelResult::InvalidFormat as u8])
+            .expect_err("short new-tunnel messages should be rejected, not sliced");
+
+        assert!(
+            err.to_string()
+                .contains("Invalid new tunnel message length"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn new_tunnel_route_blob_rejects_invalid_ping_prefix() {
+        let err = TunnelManager::new_tunnel_route_blob(&[0, 0, 0, 0, 1, 2, 3])
+            .expect_err("messages with the wrong ping prefix should be rejected");
+
+        assert!(
+            err.to_string().contains("Invalid tunnel ping prefix"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn new_tunnel_route_blob_returns_route_blob_after_ping() {
+        let mut message = PING_BYTES.to_vec();
+        message.extend([1, 2, 3]);
+
+        let route_blob = TunnelManager::new_tunnel_route_blob(&message)
+            .expect("valid ping prefix should return the remaining route blob");
+
+        assert_eq!(route_blob, &[1, 2, 3]);
+    }
 }


### PR DESCRIPTION
## Summary
- reject short or invalid new-tunnel app-call payloads before slicing the ping prefix
- return InvalidFormat for malformed app-call frames instead of treating them as successful/no-op handling
- add focused regression coverage for malformed new-tunnel payload parsing

## Verification
- cargo test new_tunnel_route_blob -- --nocapture