### PR TITLE
Upgrade to Veilid 0.5.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "veilid-iroh-blobs"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ serde_cbor = "0.11.2"
 tokio = {version = "1.38.1", features = ["full", "tracing"]}
 tokio-stream = "0.1.15"
 tracing = "0.1.40"
-veilid-core = { git = "https://gitlab.com/veilid/veilid.git", tag = "v0.5.2" }
+veilid-core = { git = "https://gitlab.com/veilid/veilid.git", tag = "v0.5.3" }
 hex = "0.4"
 
-# Patch iroh-net to relax hickory-resolver pin for veilid-core 0.5.2 compat
+# Patch iroh-net to relax hickory-resolver pin for veilid-core 0.5.3 compat
 [patch.crates-io]
 iroh-net = { git = "https://github.com/tripledoublev/iroh.git", rev = "b3f52f6d8bba462eebd7e3991946d844c9a75039" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![recursion_limit = "256"]
-use anyhow::anyhow;
 use anyhow::Result;
 use std::{
     path::{Path, PathBuf},
@@ -7,12 +6,13 @@ use std::{
 };
 use tokio::sync::broadcast;
 use tokio::sync::broadcast::Receiver;
-use veilid_core::{
-    RouteId, UpdateCallback, VeilidAPI, VeilidConfig, VeilidUpdate, VALID_CRYPTO_KINDS,
-};
+use veilid_core::{UpdateCallback, VeilidAPI, VeilidConfig, VeilidUpdate};
 
 pub mod iroh;
 pub mod tunnels;
+pub mod util;
+
+pub use util::make_route;
 
 async fn init_veilid(
     namespace: Option<String>,
@@ -68,26 +68,6 @@ async fn init_deps(
     let (veilid, rx) = init_veilid(namespace, base_dir).await?;
 
     Ok((veilid, rx, store))
-}
-
-// TODO: Put these into a utils module or something
-async fn make_route(veilid: &VeilidAPI) -> Result<(RouteId, Vec<u8>)> {
-    let mut retries = 3;
-    while retries != 0 {
-        retries -= 1;
-        let result = veilid
-            .new_custom_private_route(
-                &VALID_CRYPTO_KINDS,
-                veilid_core::Stability::LowLatency,
-                veilid_core::Sequencing::NoPreference,
-            )
-            .await;
-
-        if let Ok(route_blob) = result {
-            return Ok((route_blob.route_id, route_blob.blob));
-        }
-    }
-    Err(anyhow!("Unable to create route, reached max retries"))
 }
 
 fn config_for_dir(base_dir: PathBuf, namespace: Option<String>) -> VeilidConfig {

--- a/src/tunnels.rs
+++ b/src/tunnels.rs
@@ -13,7 +13,6 @@ use tracing::error;
 use veilid_core::OperationId;
 use veilid_core::VeilidAPI;
 use veilid_core::VeilidAppCall;
-use veilid_core::VALID_CRYPTO_KINDS;
 use veilid_core::{RouteId, RoutingContext, Target, VeilidUpdate};
 
 pub type Tunnel = (Sender<Vec<u8>>, Receiver<Vec<u8>>);
@@ -136,7 +135,7 @@ impl TunnelManagerInner {
                 }
             }
             // TODO: Better error handling?
-            let (route_id, route_id_blob) = make_route(&self.veilid).await.unwrap();
+            let (route_id, route_id_blob) = crate::make_route(&self.veilid).await.unwrap();
             self.route_id = route_id.clone();
             self.route_id_blob = route_id_blob.clone();
             if let Some(callback) = &self.on_new_route_callback {
@@ -329,7 +328,14 @@ impl TunnelManager {
         on_new_route_callback: Option<OnNewRouteCallback>,
     ) -> Result<Self> {
         let router = veilid.routing_context()?;
-        let route_blob = veilid.new_private_route().await?;
+        let route_blob = veilid
+            .new_custom_private_route(veilid_core::PrivateSpec {
+                crypto_kinds: veilid_core::VALID_CRYPTO_KINDS.to_vec(),
+                hop_count: 0,
+                stability: veilid_core::Stability::LowLatency,
+                sequencing: veilid_core::Sequencing::NoPreference,
+            })
+            .await?;
         let route_id = route_blob.route_id;
         let route_id_blob = route_blob.blob;
 
@@ -410,7 +416,9 @@ impl TunnelManager {
     ) -> Result<()> {
         while let Ok(update) = updates.recv().await {
             if let VeilidUpdate::AppCall(app_call) = update {
-                self.handle_app_call(&app_call).await?;
+                if let Err(err) = self.handle_app_call(&app_call).await {
+                    error!(error = ?err, "Error handling AppCall");
+                }
             } else if let VeilidUpdate::RouteChange(route_change) = update {
                 if !route_change.dead_remote_routes.is_empty() {
                     self.handle_remote_dead(&route_change.dead_remote_routes)
@@ -431,26 +439,6 @@ impl TunnelManager {
         self.veilid.shutdown().await;
         Ok(())
     }
-}
-
-// TODO: Put these into a utils module or something
-async fn make_route(veilid: &VeilidAPI) -> Result<(RouteId, Vec<u8>)> {
-    let mut retries = 3;
-    while retries != 0 {
-        retries -= 1;
-        let result = veilid
-            .new_custom_private_route(
-                &VALID_CRYPTO_KINDS,
-                veilid_core::Stability::LowLatency,
-                veilid_core::Sequencing::NoPreference,
-            )
-            .await;
-
-        if let Ok(route_blob) = result {
-            return Ok((route_blob.route_id, route_blob.blob));
-        }
-    }
-    Err(anyhow!("Unable to create route, reached max retries"))
 }
 
 #[cfg(test)]

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,22 @@
+use anyhow::{anyhow, Result};
+use veilid_core::{PrivateSpec, RouteId, Sequencing, Stability, VeilidAPI, VALID_CRYPTO_KINDS};
+
+pub async fn make_route(veilid: &VeilidAPI) -> Result<(RouteId, Vec<u8>)> {
+    let mut retries = 3;
+    while retries != 0 {
+        retries -= 1;
+        let result = veilid
+            .new_custom_private_route(PrivateSpec {
+                crypto_kinds: VALID_CRYPTO_KINDS.to_vec(),
+                hop_count: 0,
+                stability: Stability::LowLatency,
+                sequencing: Sequencing::NoPreference,
+            })
+            .await;
+
+        if let Ok(route_blob) = result {
+            return Ok((route_blob.route_id, route_blob.blob));
+        }
+    }
+    Err(anyhow!("Unable to create route, reached max retries"))
+}


### PR DESCRIPTION
This PR upgrades the project from Veilid 0.5.2 to 0.5.3.

### Key Changes
- **Veilid Upgrade**: Bumped veilid-core to v0.5.3. This version includes critical fixes for cold-start bootstrapping which directly address the intermittent DHT propagation timeouts observed in our tests.
- **API Update**: Implemented the new PrivateSpec API for new_custom_private_route.
- **Refactoring**: Consolidated duplicated make_route logic from src/lib.rs and src/tunnels.rs into a new src/util.rs module.
- **Robustness**: Improved the TunnelManager listener loop to log and continue on AppCall failures instead of crashing.
- **Consistency**: Unified private route creation across the codebase to consistently use LowLatency stability and NoPreference sequencing.
- **Dependency Resolution**: Resolved hickory-resolver version conflicts by unifying on 0.25.2.

Verified with cargo test -- --test-threads=1 (all 19 tests passing).