### PR TITLE
Upgrade Veilid to v0.5.4 and increase chunk size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ serde_cbor = "0.11.2"
 tokio = {version = "1.38.1", features = ["full", "tracing"]}
 tokio-stream = "0.1.15"
 tracing = "0.1.40"
-veilid-core = { git = "https://gitlab.com/veilid/veilid.git", tag = "v0.5.3" }
+veilid-core = { git = "https://gitlab.com/veilid/veilid.git", tag = "v0.5.4" }
 hex = "0.4"
 
-# Patch iroh-net to relax hickory-resolver pin for veilid-core 0.5.3 compat
+# Patch iroh-net to relax hickory-resolver pin for veilid-core 0.5.4 compat
 [patch.crates-io]
 iroh-net = { git = "https://github.com/tripledoublev/iroh.git", rev = "b3f52f6d8bba462eebd7e3991946d844c9a75039" }

--- a/src/iroh.rs
+++ b/src/iroh.rs
@@ -48,7 +48,8 @@ const DONE: u8 = 0x22u8;
 const ERR: u8 = 0xF0u8;
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_millis(32000);
-pub(crate) const FILE_CHUNK_SIZE: usize = 16 * 1024;
+// Veilid app_call payloads are capped at 32 KiB; leave room for tunnel headers.
+pub(crate) const FILE_CHUNK_SIZE: usize = 28 * 1024;
 
 pub struct VeilidIrohBlobsConfig {
     pub veilid: VeilidAPI,

--- a/src/tunnels.rs
+++ b/src/tunnels.rs
@@ -341,7 +341,7 @@ impl TunnelManager {
                 crypto_kinds: veilid_core::VALID_CRYPTO_KINDS.to_vec(),
                 hop_count: 0,
                 stability: veilid_core::Stability::LowLatency,
-                sequencing: veilid_core::Sequencing::NoPreference,
+                sequencing: veilid_core::Sequencing::PreferUnordered,
             })
             .await?;
         let route_id = route_blob.route_id;

--- a/src/util.rs
+++ b/src/util.rs
@@ -10,7 +10,7 @@ pub async fn make_route(veilid: &VeilidAPI) -> Result<(RouteId, Vec<u8>)> {
                 crypto_kinds: VALID_CRYPTO_KINDS.to_vec(),
                 hop_count: 0,
                 stability: Stability::LowLatency,
-                sequencing: Sequencing::NoPreference,
+                sequencing: Sequencing::PreferUnordered,
             })
             .await;
 


### PR DESCRIPTION
## Summary

- Upgrade `veilid-core` to `v0.5.4` and update the affected Veilid route API usage.
- Keep the `iroh-net` compatibility patch for the resolver dependency conflict.
- Increase blob transfer chunk size from 16 KiB to 28 KiB while staying under Veilid's 32 KiB `app_call` payload cap after tunnel framing overhead.

## Validation

- `cargo build`
- `cargo test -- --test-threads=1`
- `cargo test test_blob_replication_size_sweep -- --ignored --nocapture`

Note: the live Veilid/Iroh tests are run serially for this repo; concurrent `cargo test` can trip route timeouts in this app setup.
