### PR TITLE
chore: upgrade veilid-core to v0.5.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "veilid-iroh-blobs"
-version = "0.3.6"
+version = "0.3.7"
 edition = "2021"
 
 [dependencies]
@@ -18,9 +18,9 @@ serde_cbor = "0.11.2"
 tokio = {version = "1.38.1", features = ["full", "tracing"]}
 tokio-stream = "0.1.15"
 tracing = "0.1.40"
-veilid-core = { git = "https://gitlab.com/veilid/veilid.git", tag = "v0.5.4" }
+veilid-core = { git = "https://gitlab.com/veilid/veilid.git", tag = "v0.5.5" }
 hex = "0.4"
 
-# Patch iroh-net to relax hickory-resolver pin for veilid-core 0.5.4 compat
+# Patch iroh-net to relax hickory-resolver pin for veilid-core 0.5.5 compat
 [patch.crates-io]
 iroh-net = { git = "https://github.com/tripledoublev/iroh.git", rev = "b3f52f6d8bba462eebd7e3991946d844c9a75039" }


### PR DESCRIPTION
## Summary
- Bump `veilid-core` git tag `v0.5.4` → `v0.5.5` (Veilid bug-fix release: direct-reply/bootstrap fix + cargo feature-unification fix; no breaking API changes).
- Bump package version `0.3.6` → `0.3.7`.
- **Compatibility patch retained**: `hickory-resolver = "=0.25.2"` and the `tripledoublev/iroh` `iroh-net` patch are unchanged — `veilid-tools` v0.5.5 still declares `hickory-resolver = "0.25.2"`, so the constraint that required the fork is not relaxed.

## Test plan
- `cargo build` ✅
- Full `cargo test` (release) ✅ — 23 passed, 1 ignored (manual perf sweep). Includes the multi-node P2P replication/tunnel/route tests.

First step of the Veilid 0.5.5 cross-repo cascade (veilid-iroh-blobs → save-dweb-backend → save-rust).

🤖 Generated with [Claude Code](https://claude.com/claude-code)